### PR TITLE
Port to SDL2/OpenGL with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
-cmake_minimum_required(VERSION 3.31)
-project(quake)
+cmake_minimum_required(VERSION 3.15)
+project(quake C)
 
-set(CMAKE_CXX_STANDARD 26)
+# enable vcpkg toolchain if available
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "Vcpkg toolchain")
+endif()
+
+set(CMAKE_C_STANDARD 17)
 
 add_compile_definitions(GLQUAKE=1)
 

--- a/WinQuake/CMakeLists.txt
+++ b/WinQuake/CMakeLists.txt
@@ -1,8 +1,8 @@
-find_package(SDL2 REQUIRED)
+find_package(SDL2 CONFIG REQUIRED)
 find_package(OpenGL REQUIRED)
 
 add_executable(quake
-        sys_linux.c
+        sys_sdl.c
         cd_null.c
         chase.c
         cl_demo.c
@@ -24,7 +24,7 @@ add_executable(quake
         gl_rmisc.c
         gl_rsurf.c
         gl_screen.c
-        gl_vidlinuxglx.c
+        vid_sdl.c
         gl_warp.c
         host.c
         host_cmd.c
@@ -44,7 +44,7 @@ add_executable(quake
         sbar.c
         snd_dma.c
         snd_mix.c
-        snd_linux.c
+        snd_sdl.c
         snd_mem.c
         sv_main.c
         sv_user.c
@@ -56,4 +56,4 @@ add_executable(quake
         zone.c
 )
 
-target_link_libraries(quake Xxf86dga SDL2::SDL2 X11 Xxf86vm OpenGL::GL)
+target_link_libraries(quake PRIVATE SDL2::SDL2 SDL2::SDL2main OpenGL::GL)

--- a/WinQuake/snd_sdl.c
+++ b/WinQuake/snd_sdl.c
@@ -1,0 +1,49 @@
+#include "quakedef.h"
+#include <SDL.h>
+
+static SDL_AudioDeviceID audio_dev;
+
+qboolean SNDDMA_Init(void)
+{
+    SDL_AudioSpec desired, obtained;
+    SDL_zero(desired);
+    desired.freq = 44100;
+    desired.format = AUDIO_S16SYS;
+    desired.channels = 2;
+    desired.samples = 1024;
+    desired.callback = NULL;
+
+    audio_dev = SDL_OpenAudioDevice(NULL, 0, &desired, &obtained, 0);
+    if(!audio_dev)
+        return false;
+
+    shm = &sn;
+    shm->splitbuffer = 0;
+    shm->samplebits = (obtained.format == AUDIO_S16SYS) ? 16 : 8;
+    shm->speed = obtained.freq;
+    shm->channels = obtained.channels;
+    shm->samples = obtained.samples * shm->channels;
+    shm->submission_chunk = 1;
+    shm->buffer = Hunk_AllocName(shm->samples*(shm->samplebits/8), "sndbuf");
+    shm->samplepos = 0;
+
+    SDL_PauseAudioDevice(audio_dev, 0);
+    return true;
+}
+
+int SNDDMA_GetDMAPos(void)
+{
+    return shm ? shm->samplepos : 0;
+}
+
+void SNDDMA_Shutdown(void)
+{
+    if(audio_dev)
+        SDL_CloseAudioDevice(audio_dev);
+    audio_dev = 0;
+}
+
+void SNDDMA_Submit(void)
+{
+}
+

--- a/WinQuake/sys_sdl.c
+++ b/WinQuake/sys_sdl.c
@@ -1,0 +1,189 @@
+#include "quakedef.h"
+#include <SDL.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+static Uint64 sys_start_time;
+
+int nostdout = 0;
+char *basedir = ".";
+char *cachedir = ".";
+qboolean isDedicated = false;
+
+// --------------------------------------------------------------------
+// File IO support lifted from the null backend for portability
+// --------------------------------------------------------------------
+
+#define MAX_HANDLES 10
+static FILE *sys_handles[MAX_HANDLES];
+
+static int findhandle(void)
+{
+    for(int i = 1; i < MAX_HANDLES; i++)
+        if(!sys_handles[i])
+            return i;
+    Sys_Error("out of handles");
+    return -1;
+}
+
+static int filelength(FILE *f)
+{
+    int pos = ftell(f);
+    fseek(f, 0, SEEK_END);
+    int end = ftell(f);
+    fseek(f, pos, SEEK_SET);
+    return end;
+}
+
+int Sys_FileOpenRead(char *path, int *handle)
+{
+    FILE *f;
+    int h = findhandle();
+    f = fopen(path, "rb");
+    if(!f)
+    {
+        *handle = -1;
+        return -1;
+    }
+    sys_handles[h] = f;
+    *handle = h;
+    return filelength(f);
+}
+
+int Sys_FileOpenWrite(char *path)
+{
+    FILE *f;
+    int h = findhandle();
+    f = fopen(path, "wb");
+    if(!f)
+        Sys_Error("Error opening %s", path);
+    sys_handles[h] = f;
+    return h;
+}
+
+void Sys_FileClose(int handle)
+{
+    fclose(sys_handles[handle]);
+    sys_handles[handle] = NULL;
+}
+
+void Sys_FileSeek(int handle, int position)
+{
+    fseek(sys_handles[handle], position, SEEK_SET);
+}
+
+int Sys_FileRead(int handle, void *dest, int count)
+{
+    return fread(dest, 1, count, sys_handles[handle]);
+}
+
+int Sys_FileWrite(int handle, void *data, int count)
+{
+    return fwrite(data, 1, count, sys_handles[handle]);
+}
+
+int Sys_FileTime(char *path)
+{
+    FILE *f = fopen(path, "rb");
+    if(f)
+    {
+        fclose(f);
+        return 1;
+    }
+    return -1;
+}
+
+void Sys_mkdir(char *path)
+{
+#ifdef _WIN32
+    _mkdir(path);
+#else
+    mkdir(path, 0777);
+#endif
+}
+
+void Sys_Error(char *error, ...)
+{
+    va_list argptr;
+    char text[1024];
+    va_start(argptr, error);
+    vsnprintf(text, sizeof(text), error, argptr);
+    va_end(argptr);
+    fprintf(stderr, "%s\n", text);
+    SDL_Quit();
+    exit(1);
+}
+
+void Sys_Printf(char *fmt, ...)
+{
+    va_list argptr;
+    char text[1024];
+    if(nostdout)
+        return;
+    va_start(argptr, fmt);
+    vsnprintf(text, sizeof(text), fmt, argptr);
+    va_end(argptr);
+    printf("%s", text);
+}
+
+void Sys_Quit(void)
+{
+    SDL_Quit();
+    exit(0);
+}
+
+double Sys_FloatTime(void)
+{
+    return (SDL_GetTicks64() - sys_start_time) / 1000.0;
+}
+
+char *Sys_ConsoleInput(void)
+{
+    return NULL;
+}
+
+void Sys_Sleep(void)
+{
+    SDL_Delay(1);
+}
+
+void Sys_SendKeyEvents(void);
+
+void Sys_HighFPPrecision(void) {}
+void Sys_LowFPPrecision(void) {}
+void Sys_SetFPCW(void) {}
+
+int main(int argc, char **argv)
+{
+    static quakeparms_t parms;
+    parms.memsize = 16*1024*1024;
+    parms.membase = malloc(parms.memsize);
+    parms.basedir = basedir;
+    parms.cachedir = cachedir;
+
+    COM_InitArgv(argc, argv);
+    parms.argc = com_argc;
+    parms.argv = com_argv;
+    isDedicated = (COM_CheckParm("-dedicated") != 0);
+
+    if(SDL_Init(SDL_INIT_VIDEO|SDL_INIT_TIMER|SDL_INIT_AUDIO) < 0)
+        Sys_Error("SDL_Init failed: %s", SDL_GetError());
+
+    sys_start_time = SDL_GetTicks64();
+
+    Host_Init(&parms);
+
+    while(1)
+    {
+        Sys_SendKeyEvents();
+        Host_Frame(0.01);
+        SDL_Delay(1);
+    }
+}
+

--- a/WinQuake/vid_sdl.c
+++ b/WinQuake/vid_sdl.c
@@ -1,0 +1,216 @@
+#include "quakedef.h"
+#include <SDL.h>
+#include <SDL_opengl.h>
+
+float mouse_x, mouse_y;
+static SDL_Window *window = NULL;
+static SDL_GLContext glcontext = NULL;
+static int mx, my;
+
+viddef_t vid; // global video state
+unsigned short d_8to16table[256];
+unsigned d_8to24table[256];
+unsigned char d_15to8table[65536];
+
+float gldepthmin, gldepthmax;
+qboolean is8bit = false;
+qboolean isPermedia = false;
+qboolean gl_mtexable = false;
+int texture_mode = GL_LINEAR;
+int texture_extension_number = 1;
+const char *gl_vendor, *gl_renderer, *gl_version, *gl_extensions;
+cvar_t gl_ztrick = {"gl_ztrick","1"};
+
+void GL_Init(void)
+{
+    gl_vendor = (const char *)glGetString(GL_VENDOR);
+    gl_renderer = (const char *)glGetString(GL_RENDERER);
+    gl_version = (const char *)glGetString(GL_VERSION);
+    gl_extensions = (const char *)glGetString(GL_EXTENSIONS);
+
+    glClearColor(1.f, 0.f, 0.f, 0.f);
+    glCullFace(GL_FRONT);
+    glEnable(GL_TEXTURE_2D);
+    glEnable(GL_ALPHA_TEST);
+    glAlphaFunc(GL_GREATER, 0.666f);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    glShadeModel(GL_FLAT);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+}
+
+void GL_BeginRendering(int *x, int *y, int *width, int *height)
+{
+    *x = *y = 0;
+    *width = vid.width;
+    *height = vid.height;
+    glViewport(0, 0, vid.width, vid.height);
+}
+
+void GL_EndRendering(void)
+{
+    glFlush();
+    SDL_GL_SwapWindow(window);
+}
+
+qboolean VID_Is8bit(void) { return is8bit; }
+void VID_Init8bitPalette(void) {}
+
+void VID_SetPalette(unsigned char *palette)
+{
+    unsigned char *pal = palette;
+    unsigned *table = d_8to24table;
+    for(int i=0; i<256; i++)
+    {
+        unsigned r = pal[0];
+        unsigned g = pal[1];
+        unsigned b = pal[2];
+        pal += 3;
+        *table = (255u<<24) | (r<<0) | (g<<8) | (b<<16);
+        d_8to16table[i] = ((r>>3)<<11) | ((g>>2)<<5) | (b>>3);
+        table++;
+    }
+    d_8to24table[255] &= 0xffffff;
+
+    for(int i=0; i<(1<<15); i++)
+    {
+        int r = ((i & 0x1F) << 3) + 4;
+        int g = ((i & 0x03E0) >> 2) + 4;
+        int b = ((i & 0x7C00) >> 7) + 4;
+        pal = (unsigned char *)d_8to24table;
+        int bestdist = 0x7fffffff;
+        int best = 0;
+        for(int v=0; v<256; v++, pal+=4)
+        {
+            int dr = r - pal[0];
+            int dg = g - pal[1];
+            int db = b - pal[2];
+            int dist = dr*dr + dg*dg + db*db;
+            if(dist < bestdist)
+            {
+                bestdist = dist;
+                best = v;
+            }
+        }
+        d_15to8table[i] = best;
+    }
+}
+
+void VID_ShiftPalette(unsigned char *palette)
+{
+    VID_SetPalette(palette);
+}
+
+void VID_Shutdown(void)
+{
+    if(glcontext)
+        SDL_GL_DeleteContext(glcontext);
+    if(window)
+        SDL_DestroyWindow(window);
+    SDL_QuitSubSystem(SDL_INIT_VIDEO);
+}
+
+void VID_Init(unsigned char *palette)
+{
+    if(SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
+        Sys_Error("SDL video init failed: %s", SDL_GetError());
+
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    window = SDL_CreateWindow("Quake SDL2", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                              640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    if(!window)
+        Sys_Error("SDL_CreateWindow failed: %s", SDL_GetError());
+
+    glcontext = SDL_GL_CreateContext(window);
+    if(!glcontext)
+        Sys_Error("SDL_GL_CreateContext failed: %s", SDL_GetError());
+
+    SDL_GL_SetSwapInterval(1);
+
+    vid.width = vid.conwidth = 640;
+    vid.height = vid.conheight = 480;
+    vid.numpages = 1;
+    vid.maxwarpwidth = WARP_WIDTH;
+    vid.maxwarpheight = WARP_HEIGHT;
+    vid.colormap = host_colormap;
+    vid.fullbright = 256 - LittleLong(*((int *)vid.colormap + 2048));
+
+    GL_Init();
+    VID_SetPalette(palette);
+    VID_Init8bitPalette();
+    vid.recalc_refdef = 1;
+}
+
+void VID_Update(vrect_t *rects)
+{
+    SDL_GL_SwapWindow(window);
+}
+
+void VID_HandlePause(qboolean pause)
+{
+    SDL_ShowCursor(pause ? SDL_ENABLE : SDL_DISABLE);
+}
+
+int VID_SetMode(int modenum, unsigned char *palette)
+{
+    // only one mode supported
+    return true;
+}
+
+void Sys_SendKeyEvents(void)
+{
+    SDL_Event e;
+    SDL_PumpEvents();
+    while(SDL_PollEvent(&e))
+    {
+        switch(e.type)
+        {
+            case SDL_QUIT:
+                Sys_Quit();
+                break;
+            case SDL_KEYDOWN:
+            case SDL_KEYUP:
+                Key_Event(e.key.keysym.sym & 255, e.type == SDL_KEYDOWN);
+                break;
+            case SDL_MOUSEMOTION:
+                mx += e.motion.xrel;
+                my += e.motion.yrel;
+                break;
+            case SDL_MOUSEBUTTONDOWN:
+            case SDL_MOUSEBUTTONUP:
+                if(e.button.button == SDL_BUTTON_LEFT)
+                    Key_Event(K_MOUSE1, e.type == SDL_MOUSEBUTTONDOWN);
+                else if(e.button.button == SDL_BUTTON_RIGHT)
+                    Key_Event(K_MOUSE2, e.type == SDL_MOUSEBUTTONDOWN);
+                else if(e.button.button == SDL_BUTTON_MIDDLE)
+                    Key_Event(K_MOUSE3, e.type == SDL_MOUSEBUTTONDOWN);
+                break;
+        }
+    }
+}
+
+void IN_Init(void)
+{
+    SDL_SetRelativeMouseMode(SDL_TRUE);
+}
+
+void IN_Shutdown(void)
+{
+    SDL_SetRelativeMouseMode(SDL_FALSE);
+}
+
+void IN_Commands(void)
+{
+}
+
+void IN_Move(usercmd_t *cmd)
+{
+    mouse_x += mx;
+    mouse_y += my;
+    mx = my = 0;
+}
+


### PR DESCRIPTION
## Summary
- modernize root CMakeLists and enable vcpkg
- switch WinQuake build to SDL2 and add new SDL-based sources
- basic SDL2 implementations for video, system and sound
- fix palette handling in SDL video backend and ensure cmake files end with newlines

## Testing
- `cmake ..` *(fails: Could not find SDL2Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68404bc193b883238afc0a1bbc712dc3